### PR TITLE
Fix nil dereference panic on calling Trie[T].Del() when there's only one key-value pair left in the trie

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -60,6 +60,9 @@ func (t *Trie[T]) Del(key string) (ok bool) {
 
 	for ; n != nil; n = p {
 		p = n.Parent()
+		if p == nil {
+			break
+		}
 
 		if n.HasValue() {
 			n.DropValue()

--- a/trie_test.go
+++ b/trie_test.go
@@ -109,6 +109,41 @@ func TestTrieDel(t *testing.T) {
 	}
 }
 
+func TestTrieDelAll(t *testing.T) {
+	t.Parallel()
+
+	tr := trie.New[int]()
+
+	tests := []struct {
+		k string
+		v int
+	}{
+		{"bar", 1},
+		{"baz", 2},
+		{"boo", 5},
+		{"foobar", 5},
+		{"bark", 3},
+	}
+
+	for _, t := range tests {
+		tr.Add(t.k, t.v)
+	}
+
+	for _, test := range tests {
+		if _, ok := tr.Find(test.k); !ok {
+			t.Fatalf("'%s' not found", test.k)
+		}
+
+		if ok := tr.Del(test.k); !ok {
+			t.Fatalf("cannot delete '%s'", test.k)
+		}
+
+		if _, ok := tr.Find(test.k); ok {
+			t.Fatalf("'%s' found", test.k)
+		}
+	}
+}
+
 func TestTrieString(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Pull request contains the fix and a test for such case, since previously there were no cases catching this issue.